### PR TITLE
Add original tests

### DIFF
--- a/tests/async_test.js
+++ b/tests/async_test.js
@@ -1,0 +1,51 @@
+/*
+ * async_test.js
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var fdb = require('../lib/fdb').apiVersion(200);
+
+fdb.open(null, null, function(dbErr, dbVal) {
+	fdb.open(null, null, function(dbErr, dbVal) {
+		if(dbVal == null)
+			console.log("database is null");
+		console.log("created database", dbErr);
+		console.log(JSON.stringify(dbVal));
+		var tr = dbVal.createTransaction();
+		console.log("created transaction");
+
+		tr.get('foo', function(err, val) {
+			console.log("get called", val, err);
+			tr.set('foo', 'bar');
+			tr.commit(function(err) {
+				console.log("commit called", err);
+				var x = tr.get('foo');
+				x(function(err, val) {
+					console.log("get called", val.toString(), err);
+					tr.clear('foo')
+					tr.commit(function(err) {
+						console.log("commit called", err);
+						tr.get('foo', function(err, val) {
+							console.log("get called", val, err);
+						});
+					});
+				});
+			});
+		});
+	});
+});

--- a/tests/directory_extension.js
+++ b/tests/directory_extension.js
@@ -1,0 +1,304 @@
+/*
+ * directory_extension.js
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+var util = require('util');
+var fdb = require('../lib/fdb.js').apiVersion(parseInt(process.argv[3]));
+var fdbUtil = require('../lib/fdbUtil.js');
+var dirUtil = require('./directory_util.js');
+
+var logAll = false;
+
+var logInstructions = false;
+var logOps = false;
+var logDirs = false;
+var logErrors = false;
+
+var logOp = function(message, force) {
+	if(logOps || logAll || force)
+		console.log(message);
+};
+
+var DirectoryExtension = function() {
+	this.dirList = [fdb.directory];
+	this.dirIndex = 0;
+	this.errorIndex = 0;
+};
+
+DirectoryExtension.prototype.processInstruction = function(inst, cb) {
+	var self = this;
+	var directory = this.dirList[this.dirIndex];
+
+	var promiseCb = function(err) {
+		if(err && (logErrors || logAll)) {
+			console.log(err);
+			//console.log(err.stack);
+		}
+
+		dirUtil.pushError(self, inst, err);
+		cb();
+	};
+
+	var appendDir = function(dir) {
+		if(logDirs || logAll)
+			console.log(util.format('pushed at %d (op=%s)',  self.dirList.length, inst.op));
+
+		self.dirList.push(dir);
+	};
+
+	if(logAll || logInstructions)
+		console.log(inst.context.instructionIndex, inst.tokens[0].toString());
+
+	if(inst.op === 'DIRECTORY_CREATE_SUBSPACE') {
+		dirUtil.popTuples(inst)
+		.then(function(path) {
+			return inst.pop()
+			.then(function(rawPrefix) {
+				logOp(util.format('created subspace at (%s): %s',  path, fdb.buffer.printable(rawPrefix)));
+				appendDir(new fdb.Subspace(path, rawPrefix));
+			});
+		})(promiseCb);
+	}
+	else if(inst.op === 'DIRECTORY_CREATE_LAYER') {
+		inst.pop({count: 3})
+		.then(function(params) {
+			var index1 = params[0];
+			var index2 = params[1];
+			var allowManualPrefixes = params[2];
+
+			var dir1 = self.dirList[params[0]];
+			var dir2 = self.dirList[params[1]];
+			if(dir1 === null || dir2 === null) {
+				logOp('create directory layer: None');
+				appendDir(null);
+			}
+			else {
+				logOp(util.format('create directory layer: node_subspace (%d) = %s, content_subspace (%d) = %s, allow_manual_prefixes = %d', index1, fdb.buffer.printable(dir1.rawPrefix), index2, fdb.buffer.printable(dir2.rawPrefix), allowManualPrefixes));
+				appendDir(new fdb.DirectoryLayer({ nodeSubspace: dir1,
+														   contentSubspace: dir2,
+														   allowManualPrefixes: allowManualPrefixes === 1 }));
+			}
+		})(promiseCb);
+	}
+	else if(inst.op === 'DIRECTORY_CHANGE') {
+		inst.pop()
+		.then(function(index) {
+			if(self.dirList[index] === null)
+				self.dirIndex = self.errorIndex;
+			else
+				self.dirIndex = index;
+
+			if(logDirs || logAll) {
+				var dir = self.dirList[self.dirIndex];
+				console.log(util.format('changed directory to %d ((%s))', self.dirIndex, dir._path));
+			}
+		})(promiseCb);
+	}
+	else if(inst.op === 'DIRECTORY_SET_ERROR_INDEX') {
+		inst.pop()
+		.then(function(errorIndex) {
+			self.errorIndex = errorIndex;
+		})(promiseCb);
+	}
+	else if(inst.op === 'DIRECTORY_CREATE_OR_OPEN') {
+		dirUtil.popTuples(inst)
+		.then(function(path) {
+			return inst.pop()
+			.then(function(layer) {
+				logOp(util.format('create_or_open (%s): layer=%s', directory._path + path, fdb.buffer.printable(layer) || ''));
+				return directory.createOrOpen(inst.tr, path, {'layer': layer || undefined});
+			})
+			.then(function(dir) {
+				appendDir(dir);
+			});
+		})(promiseCb);
+	}
+	else if(inst.op === 'DIRECTORY_CREATE') {
+		dirUtil.popTuples(inst)
+		.then(function(path) {
+			return inst.pop({count: 2})
+			.then(function(params) {
+				logOp(util.format('create (%s): layer=%s, prefix=%s', directory._path + path, fdb.buffer.printable(params[0]) || '', fdb.buffer.printable(params[1] || '')));
+				return directory.create(inst.tr, path, {'layer': params[0] || undefined, 'prefix': params[1] || undefined});
+			})
+			.then(function(dir) {
+				appendDir(dir);
+			});
+		})(promiseCb);
+	}
+	else if(inst.op === 'DIRECTORY_OPEN') {
+		dirUtil.popTuples(inst)
+		.then(function(path) {
+			return inst.pop()
+			.then(function(layer) {
+				logOp(util.format('open (%s): layer=%s', directory._path + path, fdb.buffer.printable(layer) || ''));
+				return directory.open(inst.tr, path, {'layer': layer});
+			})
+			.then(function(dir) {
+				appendDir(dir);
+			});
+		})(promiseCb);
+	}
+	else if(inst.op === 'DIRECTORY_MOVE') {
+		dirUtil.popTuples(inst, 2)
+		.then(function(paths) {
+			logOp(util.format('move (%s) to (%s)', directory._path + paths[0], directory._path + paths[1]));
+			return directory.move(inst.tr, paths[0], paths[1])
+			.then(function(dir) {
+				appendDir(dir);
+			});
+		})(promiseCb);
+	}
+	else if(inst.op === 'DIRECTORY_MOVE_TO') {
+		dirUtil.popTuples(inst)
+		.then(function(newAbsolutePath) {
+			logOp(util.format('move (%s) to (%s)', directory._path, newAbsolutePath));
+			return directory.moveTo(inst.tr, newAbsolutePath)
+			.then(function(dir) {
+				appendDir(dir);
+			});
+		})(promiseCb);
+	}
+	else if(inst.op === 'DIRECTORY_REMOVE') {
+		inst.pop()
+		.then(function(count) {
+			return dirUtil.popTuples(inst, count)
+			.then(function(path) {
+				logOp(util.format('remove (%s)', directory._path + (path ? path : '')));
+				return directory.remove(inst.tr, path);
+			});
+		})(promiseCb);
+	}
+	else if(inst.op === 'DIRECTORY_REMOVE_IF_EXISTS') {
+		inst.pop()
+		.then(function(count) {
+			return dirUtil.popTuples(inst, count)
+			.then(function(path) {
+				logOp(util.format('remove_if_exists (%s)', directory._path + (path ? path : '')));
+				return directory.removeIfExists(inst.tr, path);
+			});
+		})(promiseCb);
+	}
+	else if(inst.op === 'DIRECTORY_LIST') {
+		inst.pop()
+		.then(function(count) {
+			return dirUtil.popTuples(inst, count)
+			.then(function(path) {
+				return directory.list(inst.tr, path);
+			})
+			.then(function(children) {
+				inst.push(fdb.tuple.pack(children));
+			});
+		})(promiseCb);
+	}
+	else if(inst.op === 'DIRECTORY_EXISTS') {
+		var path;
+		inst.pop()
+		.then(function(count) {
+			return dirUtil.popTuples(inst, count)
+			.then(function(p) {
+				path = p;
+				return directory.exists(inst.tr, path);
+			})
+			.then(function(exists) {
+				logOp(util.format('exists (%s): %d', directory._path + (path ? path : ''), exists ? 1 : 0));
+				inst.push(exists ? 1 : 0);
+			});
+		})(promiseCb);
+	}
+	else if(inst.op === 'DIRECTORY_PACK_KEY') {
+		dirUtil.popTuples(inst)
+		.then(function(keyTuple) {
+			inst.push(directory.pack(keyTuple));
+		})(promiseCb);
+	}
+	else if(inst.op === 'DIRECTORY_UNPACK_KEY') {
+		inst.pop()
+		.then(function(key) {
+			logOp(util.format('unpack %s in subspace with prefix %s', fdb.buffer.printable(key), fdb.buffer.printable(directory.rawPrefix)));
+			var tup = directory.unpack(key);
+			for(var i = 0; i < tup.length; ++i)
+				inst.push(tup[i]);
+		})(promiseCb);
+	}
+	else if(inst.op === 'DIRECTORY_RANGE') {
+		dirUtil.popTuples(inst)
+		.then(function(tup) {
+			var rng = directory.range(tup);
+			inst.push(rng.begin);
+			inst.push(rng.end);
+		})(promiseCb);
+	}
+	else if(inst.op === 'DIRECTORY_CONTAINS') {
+		inst.pop()
+		.then(function(key) {
+			inst.push(directory.contains(key) ? 1 : 0);
+		})(promiseCb);
+	}
+	else if(inst.op === 'DIRECTORY_OPEN_SUBSPACE') {
+		dirUtil.popTuples(inst)
+		.then(function(path) {
+			logOp(util.format('open_subspace (%s)', path));
+			appendDir(directory.subspace(path));
+		})(promiseCb);
+	}
+	else if(inst.op === 'DIRECTORY_LOG_SUBSPACE') {
+		inst.pop()
+		.then(function(prefix) {
+			inst.tr.set(Buffer.concat([prefix, fdb.tuple.pack([self.dirIndex])]), directory.key());
+		})(promiseCb);
+	}
+	else if(inst.op === 'DIRECTORY_LOG_DIRECTORY') {
+		inst.pop()
+		.then(function(prefix) {
+			var exists;
+			return directory.exists(inst.tr)
+			.then(function(e) {
+				exists = e;
+				if(exists)
+					return directory.list(inst.tr);
+				else
+					return [];
+			})
+			.then(function(children) {
+				var logSubspace = new fdb.Subspace([self.dirIndex], prefix);
+				inst.tr.set(logSubspace.get('path'), fdb.tuple.pack(directory.getPath()));
+				inst.tr.set(logSubspace.get('layer'), fdb.tuple.pack([directory.getLayer()]));
+				inst.tr.set(logSubspace.get('exists'), fdb.tuple.pack([exists ? 1 : 0]));
+				inst.tr.set(logSubspace.get('children'), fdb.tuple.pack(children));
+			});
+		})(promiseCb);
+	}
+	else if(inst.op === 'DIRECTORY_STRIP_PREFIX') {
+		inst.pop()
+		.then(function(str) {
+			if(!fdbUtil.buffersEqual(fdb.buffer(str).slice(0, directory.key().length), directory.key()))
+				throw new Error('String ' + str + ' does not start with raw prefix ' + directory.key());
+
+			inst.push(str.slice(directory.key().length));
+		})(promiseCb);
+	}
+	else {
+		throw new Error('Unknown op: ' + inst.op);
+	}
+};
+
+module.exports = DirectoryExtension;

--- a/tests/directory_util.js
+++ b/tests/directory_util.js
@@ -1,0 +1,77 @@
+/*
+ * directory_util.js
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+var fdb = require('../lib/fdb.js').apiVersion(parseInt(process.argv[3]));
+var util = require('../lib/fdbUtil.js');
+
+var opsThatCreateDirs = [
+    'DIRECTORY_CREATE_SUBSPACE',
+    'DIRECTORY_CREATE_LAYER',
+    'DIRECTORY_CREATE_OR_OPEN',
+    'DIRECTORY_CREATE',
+    'DIRECTORY_OPEN',
+    'DIRECTORY_MOVE',
+    'DIRECTORY_MOVE_TO',
+    'DIRECTORY_OPEN_SUBSPACE'
+];
+
+var popTuples = function(inst, num, cb) {
+	if(typeof num === 'undefined')
+		num = 1;
+	return fdb.future.create(function(futureCb) {
+		var tuples = [];
+		if(num === 0) return futureCb();
+		util.whileLoop(function(loopCb) {
+			inst.pop()
+			.then(function(count) {
+				return inst.pop({count: count})
+				.then(function(tuple) {
+					tuples.push(tuple);
+					if(--num === 0)
+						return null;
+				});
+			})(loopCb);
+		}, function() {
+			if(tuples.length == 1)
+				futureCb(undefined, tuples[0]);
+			else 
+				futureCb(undefined, tuples);
+		});
+	})(cb);
+};
+
+var pushError = function(self, inst, err) {
+	if(err) {
+		//console.log(err.toString());
+		//console.log(err.stack);
+		inst.push(fdb.buffer('DIRECTORY_ERROR'));
+
+		if(opsThatCreateDirs.indexOf(inst.op) >= 0)
+			self.dirList.push(null);
+	}
+
+	return err;
+};
+
+module.exports = {
+	popTuples: popTuples,
+	pushError: pushError
+};

--- a/tests/get_range.js
+++ b/tests/get_range.js
@@ -1,0 +1,62 @@
+/*
+ * get_range.js
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var fdb = require('../lib/fdb').apiVersion(200);
+
+var db = fdb.open(null, null)
+
+var tr = db.createTransaction();
+
+for(var i = 0; i < 10000; i++)
+	tr.set('foo' + i, 'bar' + i)
+
+tr.commit(function(err) {
+	if(err)
+		console.log('commit error', err);
+
+	console.log('get range: foo-fooa');
+	var itr = tr.getRange('foo', 'fooa', null);
+
+	itr.forEach(
+		function(val, cb) {
+			console.log(val.key.toString(), val.value.toString());
+			cb();
+		},
+		function(err, res) {
+			if(err)
+				console.log(err);
+			else {
+				itr.forEach(
+					function(val, cb) {
+						console.log('pass2: ' + val.key.toString(), val.value.toString());
+						cb();
+					},
+					function(err, res) {
+						if(err)
+							console.log(err);
+						else { }
+					}
+				);
+			}
+		}
+	);
+});
+
+

--- a/tests/get_versionstamp.js
+++ b/tests/get_versionstamp.js
@@ -1,0 +1,59 @@
+/*
+ * get_versionstamp.js
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var bufferEqual = function (a, b) {
+    if (!Buffer.isBuffer(a)) return undefined;
+    if (!Buffer.isBuffer(b)) return undefined;
+    if (typeof a.equals === 'function') return a.equals(b);
+    if (a.length !== b.length) return false;
+
+    for (var i = 0; i < a.length; i++) {
+        if (a[i] !== b[i]) return false;
+    }
+
+    return true;
+};
+
+var fdb = require('../lib/fdb').apiVersion(410);
+
+var db = fdb.open(null, null)
+
+var tr = db.createTransaction();
+
+tr.getVersionstamp(function(error, vs) {
+    db.get('foo', function(error, val) {
+        if(bufferEqual(val, vs))
+            console.log('versionstamps match!')
+        else {
+            console.log("versionstamps don't match!")
+            console.log("database verionstamp: " + val)
+            console.log("transaction versionstamp: " + vs)
+        }
+    });
+});
+
+tr.setVersionstampedValue('foo', 'blahblahbl')
+
+tr.commit(function(err) {
+	if(err)
+		console.log('commit error', err);
+
+	console.log(tr.getCommittedVersion())
+});

--- a/tests/promise_aplus_test.js
+++ b/tests/promise_aplus_test.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+/*
+ * promise_aplus_test.js
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+var promisesAplusTests = require('promises-aplus-tests');
+var future = require('../lib/future.js');
+
+var adapter = {
+	resolved: function(value) {
+		var f = future.create();
+		f._state.fulfill(value);
+		return f;
+	},
+
+	rejected: function(reason) {
+		var f = future.create();
+		f._state.reject(reason);
+		return f;
+	},
+
+	deferred: function() {
+		var f = future.create();
+
+		return {
+			promise: f,
+			resolve: function(value) {
+				f._state.fulfill(value);
+			},
+			reject: function(reason) {
+				f._state.reject(reason);
+			},
+		};
+	}
+};
+
+promisesAplusTests(adapter, function(err) {
+	console.log('Finished tests:', err);
+});

--- a/tests/retry_test.js
+++ b/tests/retry_test.js
@@ -1,0 +1,58 @@
+/*
+ * retry_test.js
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var fdb = require('../lib/fdb').apiVersion(200);
+
+function set(db, key, value, cb) {
+	db.doTransaction(function(tr, cb2) {
+		console.log("setting key");
+		tr.set(new Buffer(key), new Buffer(value));
+		cb2(null);
+	}, cb);
+};
+
+function setTxn(tr, key, value, cb) {
+	console.log('calling set');
+	tr.set(new Buffer(key), new Buffer(value));
+	cb();
+};
+setTxn = fdb.transactional(setTxn);
+
+function getAndClear(db, key, cb) {
+	db.doTransaction(function(tr, cb2) {
+		console.log("getting key");
+		tr.get(new Buffer(key), function(err, res) {
+			tr.clear(new Buffer(key));
+			//setTimeout(function() { cb2(err, res); }, 6000);
+			cb2(err, res);
+		});
+	}, cb);
+};
+
+fdb.open(null, null, function(dbErr, db) {
+	console.log("created database", dbErr);
+	setTxn(db, 'foo', 'bar', function(err) {
+		console.log("Called transactional function", err);
+		getAndClear(db, 'foo', function(err, res) {
+			console.log("Called get and clear", err, res.toString());
+		});
+	});
+});
+

--- a/tests/streamline_async_test._js
+++ b/tests/streamline_async_test._js
@@ -1,0 +1,33 @@
+var fdb = require('../lib/fdb').apiVersion(200);
+
+function doSomething(_){
+	console.log("start");
+	db = fdb.open(null, null);
+	db = db(_);
+	db = fdb.open(null, null);
+	db = db(_);
+
+	a = db.get('foo');
+	console.log('foo = ', a(_));
+	db.clear('foo', 'bar', _);
+	console.log('foo = ', db.get('foo', _));
+	b = db.set('foo', 'bar');
+	b(_);
+	console.log('foo = ', db.get('foo', _));
+
+	/*var tr = db.createTransaction();
+	tr.set(new Buffer('foo'), new Buffer('bar'));
+	tr.commit(_);
+
+	var a = tr.get(new Buffer('foo'))
+	var b = tr.get(new Buffer('bar'))
+
+	console.log(a(_));
+	console.log(b(_));
+
+	var c = tr.get(new Buffer('a'));
+	console.log(c(_));*/
+}
+
+doSomething(_);
+console.log("after");

--- a/tests/streamline_directory_extension._js
+++ b/tests/streamline_directory_extension._js
@@ -1,0 +1,148 @@
+"use strict";
+
+var fdb = require('../lib/fdb.js').apiVersion(parseInt(process.argv[3]));
+var fdbUtil = require('../lib/fdbUtil.js');
+var dirUtil = require('./directory_util.js');
+
+var StreamlineDirectoryExtension = function() {
+	this.dirList = [fdb.directory];
+	this.dirIndex = 0;
+	this.errorIndex = 0;
+};
+
+StreamlineDirectoryExtension.prototype.processInstruction = function(inst, _) {
+	var directory = this.dirList[this.dirIndex];
+
+	try {
+		//console.log(inst.op);
+
+		if(inst.op === 'DIRECTORY_CREATE_SUBSPACE') {
+			var path = dirUtil.popTuples(inst)(_);
+			var rawPrefix = inst.pop()(_);
+			this.dirList.push(new fdb.Subspace(path, rawPrefix));
+		}
+		else if(inst.op === 'DIRECTORY_CREATE_LAYER') {
+			var params = inst.pop({count: 3})(_);
+			if(this.dirList[params[0]] === null || this.dirList[params[1]] === null)
+				this.dirList.push(null);
+			else {
+				this.dirList.push(new fdb.DirectoryLayer({ nodeSubspace: this.dirList[params[0]], 
+														   contentSubspace: this.dirList[params[1]],
+														   allowManualPrefixes: params[2] }));
+			}
+		}
+		else if(inst.op === 'DIRECTORY_CHANGE') {
+			var index = inst.pop()(_);
+			if(this.dirList[index] === null)
+				this.dirIndex = this.errorIndex;
+			else
+				this.dirIndex = index;
+		}
+		else if(inst.op === 'DIRECTORY_SET_ERROR_INDEX') {
+			this.errorIndex = inst.pop()(_);
+		}
+		else if(inst.op === 'DIRECTORY_CREATE_OR_OPEN') {
+			var path = dirUtil.popTuples(inst)(_);
+			var layer = inst.pop()(_);
+			var dir = directory.createOrOpen(inst.tr, path, {'layer': layer || undefined})(_);
+			this.dirList.push(dir);
+		}
+		else if(inst.op === 'DIRECTORY_CREATE') {
+			var path = dirUtil.popTuples(inst)(_);
+			var params = inst.pop({count: 2})(_);
+			var dir = directory.create(inst.tr, path, {'layer': params[0] || undefined, 'prefix': params[1] || undefined})(_);
+			this.dirList.push(dir);
+		}
+		else if(inst.op === 'DIRECTORY_OPEN') {
+			var path = dirUtil.popTuples(inst)(_);
+			var layer = inst.pop()(_);
+			var dir = directory.open(inst.tr, path, {'layer': layer || undefined})(_);
+			this.dirList.push(dir);
+		}
+		else if(inst.op === 'DIRECTORY_MOVE') {
+			var paths = dirUtil.popTuples(inst, 2)(_);
+			var movedDir = directory.move(inst.tr, paths[0], paths[1])(_);
+			this.dirList.push(movedDir);
+		}
+		else if(inst.op === 'DIRECTORY_MOVE_TO') {
+			var newAbsolutePath = dirUtil.popTuples(inst)(_);
+			var movedDir = directory.moveTo(inst.tr, newAbsolutePath)(_);
+			this.dirList.push(movedDir);
+		}
+		else if(inst.op === 'DIRECTORY_REMOVE') {
+			var count = inst.pop()(_);
+			var path = dirUtil.popTuples(inst, count)(_);
+			directory.remove(inst.tr, path)(_);
+		}
+		else if(inst.op === 'DIRECTORY_REMOVE_IF_EXISTS') {
+			var count = inst.pop()(_);
+			var path = dirUtil.popTuples(inst, count)(_);
+			directory.removeIfExists(inst.tr, path)(_);
+		}
+		else if(inst.op === 'DIRECTORY_LIST') {
+			var count = inst.pop()(_);
+			var path = dirUtil.popTuples(inst, count)(_);
+			var children = directory.list(inst.tr, path)(_);
+			inst.push(fdb.tuple.pack(children));
+		}
+		else if(inst.op === 'DIRECTORY_EXISTS') {
+			var count = inst.pop()(_);
+			var path = dirUtil.popTuples(inst, count)(_);
+			var exists = directory.exists(inst.tr, path)(_);
+			inst.push(exists ? 1 : 0);
+		}
+		else if(inst.op === 'DIRECTORY_PACK_KEY') {
+			var keyTuple = dirUtil.popTuples(inst)(_);
+			inst.push(directory.pack(keyTuple));
+		}
+		else if(inst.op === 'DIRECTORY_UNPACK_KEY') {
+			var key = inst.pop()(_);
+			var tup = directory.unpack(key);
+			for(var i = 0; i < tup.length; ++i)
+				inst.push(tup[i]);
+		}
+		else if(inst.op === 'DIRECTORY_RANGE') {
+			var tup = dirUtil.popTuples(inst)(_);
+			var rng = directory.range(tup);
+			inst.push(rng.begin);
+			inst.push(rng.end);
+		}
+		else if(inst.op === 'DIRECTORY_CONTAINS') {
+			var key = inst.pop()(_);
+			inst.push(directory.contains(key) ? 1 : 0);
+		}
+		else if(inst.op === 'DIRECTORY_OPEN_SUBSPACE') {
+			var path = dirUtil.popTuples(inst)(_);
+			this.dirList.push(directory.subspace(path));
+		}
+		else if(inst.op === 'DIRECTORY_LOG_SUBSPACE') {
+			var prefix = inst.pop()(_);
+			inst.tr.set(Buffer.concat([prefix, fdb.tuple.pack([this.dirIndex])]), directory.key());
+		}
+		else if(inst.op === 'DIRECTORY_LOG_DIRECTORY') {
+			var prefix = inst.pop()(_);
+			var exists = directory.exists(inst.tr)(_);
+			var children = exists ? directory.list(inst.tr)(_) : [];
+			var logSubspace = new fdb.Subspace([this.dirIndex], prefix);
+			inst.tr.set(logSubspace.get('path'), fdb.tuple.pack(directory.getPath()));
+			inst.tr.set(logSubspace.get('layer'), fdb.tuple.pack([directory.getLayer()]));
+			inst.tr.set(logSubspace.get('exists'), fdb.tuple.pack([exists ? 1 : 0]));
+			inst.tr.set(logSubspace.get('children'), fdb.tuple.pack(children));
+		}
+		else if(inst.op === 'DIRECTORY_STRIP_PREFIX') {
+			var str = inst.pop()(_);
+			if(!fdbUtil.buffersEqual(fdb.buffer(str).slice(0, directory.key().length), directory.key()))
+				throw new Error('String ' + str + ' does not start with raw prefix ' + directory.key());
+
+			inst.push(str.slice(directory.key().length));
+		}
+		else {
+			throw new Error('Unknown op: ' + inst.op);
+		}
+	}
+	catch(err) {
+		dirUtil.pushError(this, inst, err);
+	}
+};
+
+module.exports = StreamlineDirectoryExtension;

--- a/tests/streamline_get_range._js
+++ b/tests/streamline_get_range._js
@@ -1,0 +1,41 @@
+var fdb = require('../lib/fdb').apiVersion(200);
+
+db = fdb.open(null, null, _);
+
+var tr = db.createTransaction();
+
+tr.set('foo1', 'bar1');
+tr.set('foo2', 'bar2');
+tr.set('foo3', 'bar3');
+tr.set('foo4', 'bar4');
+tr.set('foo5', 'bar5');
+tr.set('bar1', 'foo1');
+tr.set('bar2', 'foo2');
+
+tr.commit(_);
+
+console.log('get range: foo1-foo4');
+var itr = tr.getRange('foo1', 'foo4', null);
+
+a = itr.forEach(function(val, cb) {
+	console.log(val.key.toString(), val.value.toString()); 
+	cb(null, null);
+});
+
+console.log('get range starts with: foo');
+itr = tr.getRangeStartsWith('foo');
+
+b = itr.forEachBatch(function(arr, cb) {
+	console.log('processing array', arr.length);
+	for(var i in arr) 
+		console.log(arr[i].key.toString(), arr[i].value.toString());
+	cb(null, null);
+});
+c = itr.forEachBatch(function(arr, cb) {
+	console.log('processing array concurrent', arr.length);
+	for(var i in arr)
+		console.log(arr[i].key.toString(), arr[i].value.toString());
+	cb(null, null);
+});
+
+console.log(a(_) + b(_) + c(_));

--- a/tests/streamline_retry._js
+++ b/tests/streamline_retry._js
@@ -1,0 +1,48 @@
+var fdb = require('../lib/fdb').apiVersion(200);
+
+function set(db, key, value, _) {
+	db.doTransaction(function(tr, _) {
+		console.log("setting key");
+		tr.set(key, value);
+		return;
+	}, _);
+};
+
+function getAndClear(db, key, _) {
+	a = db.doTransaction(function(tr, _) {
+		console.log("getting key");
+		res = tr.get(key, _);
+		tr.clear(key);
+		return res;
+	});
+
+	b = db.doTransaction(function(tr, _) {
+		console.log("getting key");
+		res = tr.get(key, _);
+		tr.clear(key);
+		return res;
+	});
+
+	return a(_) + b(_);
+};
+
+getAndClearTxn = fdb.transactional(function(tr, key, _) {
+	console.log("getting key");
+	tr.getKey(fdb.KeySelector.firstGreaterOrEqual(key));
+	res = tr.get(key, _);
+	tr.clear(key);
+	return res;
+});
+
+db = fdb.open(null, null, _);
+set(db, 'foo', 'bar', _);
+
+//res = getAndClear(db, 'foo');
+//console.log("Called get and clear", res(_).toString());
+
+a = getAndClearTxn(db, 'foo');
+b = getAndClearTxn(db, 'foo');
+
+res = a(_) + b(_);
+console.log("Result:", res.toString());
+

--- a/tests/streamline_tester._js
+++ b/tests/streamline_tester._js
@@ -1,0 +1,464 @@
+#!/usr/bin/env _node
+
+"use strict";
+
+//cmd line: _node streamline_tester._js <test_prefix> <optional_cluster_file>
+var startTestPrefix = process.argv[2];
+
+var assert = require('assert');
+var fdb = require('../lib/fdb.js').apiVersion(parseInt(process.argv[3]));
+var fdbUtil = require('../lib/fdbUtil.js');
+var testerUtil = require('./util.js');
+var DirectoryExtension = require('./streamline_directory_extension._js');
+
+var db = fdb.open(process.argv[4]);
+
+function pushError(inst, err) {
+	if(err) {
+		if(!err.code)
+			throw err;
+
+		inst.push(fdb.tuple.pack([fdb.buffer('ERROR'), fdb.buffer(err.code.toString())]));
+	}
+
+	return err;
+}
+
+var rangeChoice = 0;
+function pushRange(itr, inst, prefixFilter, _) {
+	var outArray = [];
+
+	function pushKV(kv) { 
+		if(typeof prefixFilter === 'undefined' || prefixFilter === null ||  fdbUtil.buffersEqual(kv.key.slice(0, prefixFilter.length), prefixFilter)) {
+			outArray.push(kv.key);
+			outArray.push(kv.value);
+		}
+	}
+
+	//Test the different methods for getting data from a range
+	if(inst.isDatabase) {
+		for(var i = 0; i < itr.length; ++i)
+			pushKV(itr[i]);
+	}
+	else if(rangeChoice % 4 === 0) {
+		itr.forEachBatch(function(res, _) {
+			for(var i = 0; i < res.length; ++i)
+				pushKV(res[i]);
+
+			if(rangeChoice % 8 === 0)
+				setTimeout(_, 0);
+		}, _);
+	}
+	else if(rangeChoice % 4 === 1) {
+		itr.forEach(function(res, _) {
+			pushKV(res);
+			if(rangeChoice % 8 === 1)
+				setTimeout(_, 0);
+		}, _);
+	}
+	else if(rangeChoice % 4 === 2) {
+		var arr = itr.toArray(_);
+		for(var i = 0; i < arr.length; ++i)
+			pushKV(arr[i]);
+	}
+	else {
+		fdbUtil.whileLoop(function(_) {
+			var kv = itr.next(_);
+			if(!kv)
+				return null;
+			else
+				pushKV(kv);
+		}, _);
+	}
+
+	rangeChoice++;
+	inst.push(fdb.tuple.pack(outArray));
+}
+
+var waitEmpty = fdb.transactional(function(tr, prefix, _) {
+	var itr = tr.getRangeStartsWith(prefix, { limit: 1 });
+	var arr = itr.toArray(_);
+
+	if(arr.length > 0)
+		throw new fdb.FDBError('', 1020);
+});
+
+var testWatches = function(db, _) {
+	db.set('w0', '0', _);
+	db.set('w3', '3', _);
+
+	var ready = [ false, false, false, false ];
+
+	var watches = [];
+	watches[0] = db.doTransaction(function(tr, _) {
+		return tr.watch('w0');
+	}, _);
+
+	watches[1] = db.clearAndWatch('w1', _).watch;
+	watches[2] = db.setAndWatch('w2', '2', _).watch;
+	watches[3] = db.getAndWatch('w3', _);
+
+	assert.strictEqual(watches[3].value.toString(), '3', 'get and watch');
+	watches[3] = watches[3].watch;
+
+	for(var i = 0; i < watches.length; ++i) {
+		(function(i) {
+			watches[i](function(err) { if(!err) ready[i] = true; });
+		})(i);
+	}
+
+	function checkWatches(expected, testName) {
+		for(var i = 0; i < watches.length; ++i)
+			assert.strictEqual(ready[i], expected, 'testName' + i);
+	}
+
+	setTimeout(_, 1000);
+	checkWatches(false, 'test 1');
+
+	db.set('w0', '0', _);
+	db.clear('w1', _);
+
+	setTimeout(_, 5000);
+	checkWatches(false, 'test 2');
+
+	db.set('w0', 'a', _);
+	db.set('w1', 'b', _);
+	db.clear('w2', _);
+	db.xor('w3', fdb.buffer.fromByteLiteral('\xff\xff'), _);
+
+	setTimeout(_, 2000);
+	checkWatches(true, 'test 3');
+};
+
+var testLocality = function(_) {
+	db.doTransaction(function(tr, _) {
+		tr.options.setTimeout(60*1000);
+		tr.options.setReadSystemKeys();
+
+		var boundaryKeys = fdb.locality.getBoundaryKeys(tr, '', fdb.buffer.fromByteLiteral('\xff\xff'), _).toArray(_);
+		var success = true;
+
+		for(var i = 0; i < boundaryKeys.length-1; ++i) {
+			var start = boundaryKeys[i];
+			var end = tr.getKey(fdb.KeySelector.lastLessThan(boundaryKeys[i+1]), _);
+			var startAddresses = fdb.locality.getAddressesForKey(tr, start, _);
+			var endAddresses = fdb.locality.getAddressesForKey(tr, end, _);
+			for(var j = 0; j < startAddresses.length; ++j) {
+				var found = false;
+				for(var k = 0; k < endAddresses.length; ++k) {
+					if(startAddresses[j].toString() === endAddresses[k].toString()) {
+						found = true;
+						break;
+					}
+				}
+
+				if(!found) {
+					success = false;
+					break;
+				}
+			}
+
+			if(!success)
+				break;
+		}
+
+		if(!success)
+			throw(new Error('Locality not internally consistent'));
+	}, _);
+}
+
+var numOperations = 0;
+function processOperation(context, inst, _) {
+	//if(inst.op !== 'SWAP' && inst.op !== 'PUSH')
+		//console.log(context.prefix + ':', context.instructionIndex + '.', inst.op);
+
+	var params, numParams, res, itr;
+
+	try {
+		if(inst.op === 'PUSH')
+			inst.push(inst.tokens[1]);
+		else if(inst.op === 'POP')
+			inst.pop()(_);
+		else if(inst.op === 'DUP')
+			context.stack.pushEntry(context.stack.get(context.stack.length()-1));
+		else if(inst.op === 'EMPTY_STACK')
+			context.stack = new testerUtil.Stack();
+		else if(inst.op === 'SWAP') {
+			var index = inst.pop()(_);
+			assert.strictEqual(context.stack.length() > index, true, 'Cannot swap; stack too small');
+			index = context.stack.length() - index - 1;
+			if(context.stack.length() > index + 1) {
+				var tmp = context.stack.get(index);
+				context.stack.set(index, context.stack.popEntry());
+				context.stack.pushEntry(tmp);
+			}
+		}
+		else if(inst.op === 'WAIT_FUTURE') {
+			var stackEntry = inst.pop({withMetadata: true})(_);
+			context.stack.pushEntry(stackEntry);
+		}
+		else if(inst.op === 'WAIT_EMPTY') {
+			var waitKey = inst.pop()(_);
+			waitEmpty(db, waitKey, _);
+			inst.push('WAITED_FOR_EMPTY');
+		}
+		else if(inst.op === 'START_THREAD') { 
+			var prefix = inst.pop()(_);
+			processTest(prefix, function(err, res) {
+				if(err) {
+					console.error('ERROR in Thread', prefix + ':');
+					console.error(err.stack);
+					process.exit(1);
+				}
+			});
+		}
+		else if(inst.op === 'NEW_TRANSACTION') {
+			context.newTransaction();
+		}
+		else if(inst.op === 'USE_TRANSACTION') {
+			var name = inst.pop()(_);
+			context.switchTransaction(name);
+		}
+		else if(inst.op === 'SET') {
+			params = inst.pop({count: 2})(_);
+
+			res = inst.tr.set(params[0], params[1]);
+			if(inst.isDatabase)
+				inst.push(res, true);
+		}
+		else if(inst.op === 'CLEAR') {
+			var key = inst.pop()(_);
+
+			res = inst.tr.clear(key);
+			if(inst.isDatabase)
+				inst.push(res, true);
+		}
+		else if(inst.op === 'CLEAR_RANGE') {
+			params = inst.pop({count: 2})(_);
+
+			res = inst.tr.clearRange(params[0], params[1]);
+			if(inst.isDatabase)
+				inst.push(res, true);
+		}
+		else if(inst.op === 'CLEAR_RANGE_STARTS_WITH') {
+			var prefix = inst.pop()(_);
+
+			res = inst.tr.clearRangeStartsWith(prefix);
+			if(inst.isDatabase)
+				inst.push(res, true);
+		}
+		else if(inst.op === 'ATOMIC_OP') {
+			params = inst.pop({count: 3})(_);
+
+			res = inst.tr[testerUtil.toJavaScriptName(params[0])](params[1], params[2]);
+			if(inst.isDatabase)
+				inst.push(res, true);
+		}
+		else if(inst.op === 'COMMIT') {
+			inst.push(inst.tr.commit(), true);
+		}
+		else if(inst.op === 'RESET')
+			inst.tr.reset();
+		else if(inst.op === 'CANCEL')
+			inst.tr.cancel();
+		else if(inst.op === 'GET') {
+			var key = inst.pop()(_);
+			inst.push(inst.tr.get(key), true);
+		}
+		else if(inst.op === 'GET_RANGE') {
+			params = inst.pop({count: 5})(_);
+
+			if(inst.isDatabase)
+				itr = inst.tr.getRange(params[0], params[1], { limit: params[2], reverse: params[3], streamingMode: params[4] }, _);
+			else
+				itr = inst.tr.getRange(params[0], params[1], { limit: params[2], reverse: params[3], streamingMode: params[4] });
+
+			pushRange(itr, inst, undefined, _);
+		}
+		else if(inst.op === 'GET_RANGE_SELECTOR') {
+			params = inst.pop({count: 10})(_);
+
+			var start = new fdb.KeySelector(params[0], params[1], params[2]);
+			var end = new fdb.KeySelector(params[3], params[4], params[5]);
+
+			if(inst.isDatabase)
+				itr = inst.tr.getRange(start, end, { limit: params[6], reverse: params[7], streamingMode: params[8] }, _);
+			else
+				itr = inst.tr.getRange(start, end, { limit: params[6], reverse: params[7], streamingMode: params[8] });
+
+			pushRange(itr, inst, params[9], _);
+		}
+		else if(inst.op === 'GET_RANGE_STARTS_WITH') {
+			params = inst.pop({count: 4})(_);
+
+			if(inst.isDatabase)
+				itr = inst.tr.getRangeStartsWith(params[0], { limit: params[1], reverse: params[2], streamingMode: params[3] }, _);
+			else
+				itr = inst.tr.getRangeStartsWith(params[0], { limit: params[1], reverse: params[2], streamingMode: params[3] });
+
+			pushRange(itr, inst, undefined, _);
+		}
+		else if(inst.op === 'GET_KEY') {
+			params = inst.pop({count: 4})(_);
+			var key = inst.tr.getKey(new fdb.KeySelector(params[0], params[1], params[2]), _);
+
+			if(fdbUtil.buffersEqual(key.slice(0, params[3].length), params[3])) {
+				inst.push(key);
+			}
+			else if(fdb.buffer.toByteLiteral(key) < fdb.buffer.toByteLiteral(params[3])) {
+				inst.push(params[3]);
+			}
+			else {
+				inst.push(fdbUtil.strinc(params[3]));
+			}
+		}
+		else if(inst.op === 'READ_CONFLICT_RANGE') {
+			params = inst.pop({count: 2})(_);
+			inst.tr.addReadConflictRange(params[0], params[1]);
+			inst.push(fdb.buffer('SET_CONFLICT_RANGE'));
+		}
+		else if(inst.op === 'WRITE_CONFLICT_RANGE') {
+			params = inst.pop({count: 2})(_);
+			inst.tr.addWriteConflictRange(params[0], params[1]);
+			inst.push(fdb.buffer('SET_CONFLICT_RANGE'));
+		}
+		else if(inst.op === 'READ_CONFLICT_KEY') {
+			var key = inst.pop()(_);
+			inst.tr.addReadConflictKey(key);
+			inst.push(fdb.buffer('SET_CONFLICT_KEY'));
+		}
+		else if(inst.op === 'WRITE_CONFLICT_KEY') {
+			var key = inst.pop()(_);
+			inst.tr.addWriteConflictKey(key);
+			inst.push(fdb.buffer('SET_CONFLICT_KEY'));
+		}
+		else if(inst.op === 'DISABLE_WRITE_CONFLICT') {
+			inst.tr.options.setNextWriteNoWriteConflictRange();
+		}
+		else if(inst.op === 'GET_READ_VERSION') {
+			context.lastVersion = inst.tr.getReadVersion(_);
+			inst.push(fdb.buffer('GOT_READ_VERSION'));
+		}
+		else if(inst.op === 'GET_COMMITTED_VERSION') {
+			context.lastVersion = inst.tr.getCommittedVersion();
+			inst.push(fdb.buffer('GOT_COMMITTED_VERSION'));
+		}
+		else if(inst.op === 'GET_VERSIONSTAMP') {
+			inst.push(inst.tr.getVersionstamp(), true);
+		}
+		else if(inst.op === 'SET_READ_VERSION') {
+			assert.notStrictEqual(typeof context.lastVersion, 'undefined', 'Cannot set read version; version has never been read');
+			inst.tr.setReadVersion(context.lastVersion);
+		}
+		else if(inst.op === 'ON_ERROR') {
+			var errorCode = inst.pop()(_);
+			var testErr = new fdb.FDBError('', errorCode);
+			
+			inst.push(inst.tr.onError(testErr), true);
+		}
+		else if(inst.op === 'TUPLE_PACK') {
+			numParams = inst.pop()(_);
+			params = inst.pop({count: numParams})(_);
+			inst.push(fdb.tuple.pack(params));
+		}
+		else if(inst.op === 'TUPLE_UNPACK') {
+			var packedTuple = inst.pop()(_);
+			var arr = fdb.tuple.unpack(packedTuple);
+			for(var i = 0; i < arr.length; ++i)
+				inst.push(fdb.tuple.pack([arr[i]]));
+		}
+		else if(inst.op === 'TUPLE_RANGE') {
+			numParams = inst.pop()(_);
+			params = inst.pop({count: numParams})(_);
+			var range = fdb.tuple.range(params);
+			inst.push(range.begin);
+			inst.push(range.end);
+		}
+		else if(inst.op === 'SUB') {
+			params = inst.pop({count: 2})(_);
+			inst.push(params[0] - params[1]);
+		}
+		else if(inst.op === 'CONCAT') {
+			params = inst.pop({count: 2})(_);
+			if(Buffer.isBuffer(params[0])) {
+				inst.push(Buffer.concat([params[0], params[1]]))
+			}
+			else {
+				inst.push(params[0] + params[1]);
+			}
+		}
+		else if(inst.op === 'LOG_STACK') {
+			var prefix = inst.pop()(_);
+			var items = inst.pop({count: context.stack.length(), withMetadata: true})(_);
+
+			for(var i = 0; i < items.length; ++i) {
+				if(i % 100 === 0)
+					inst.tr.commit(_);
+					inst.tr.reset();
+
+				var entry = items[items.length - i -1];
+				var packedSubKey = fdb.tuple.pack([i, entry.instructionIndex]);
+
+				var packedValue = fdb.tuple.pack([entry.item]);
+				if(packedValue.length > 40000)
+					packedValue = packedValue.slice(0, 40000);
+
+				inst.tr.set(Buffer.concat([prefix, packedSubKey], prefix.length + packedSubKey.length), packedValue);
+			}
+
+			inst.tr.commit(_);
+			inst.tr.reset();
+		}
+		else if(inst.op === 'UNIT_TESTS') {
+			try {
+				db.options.setLocationCacheSize(100001);
+				db.doTransaction(function(tr, _) {
+					tr.options.setPrioritySystemImmediate();
+					tr.options.setPriorityBatch();
+					tr.options.setCausalReadRisky();
+					tr.options.setCausalWriteRisky();
+					tr.options.setReadYourWritesDisable();
+					tr.options.setReadAheadDisable();
+					tr.options.setReadSystemKeys();
+					tr.options.setAccessSystemKeys();
+					tr.options.setDurabilityDevNullIsWebScale();
+					tr.options.setTimeout(1000);
+					tr.options.setRetryLimit(5);
+					tr.options.setMaxRetryDelay(100);
+					tr.options.setUsedDuringCommitProtectionDisable();
+					tr.options.setTransactionLoggingEnable('my_transaction');
+
+					tr.get(fdb.buffer.fromByteLiteral('\xff'), _);
+				}, _);
+
+				testWatches(db, _);
+				testLocality(_);
+			}
+			catch(err) {
+				throw('Unit tests failed: ' + err);
+			}
+		}
+		else if(testerUtil.startsWith(inst.op, 'DIRECTORY_')) {
+			context.directoryExtension.processInstruction(inst, _);
+		}
+		else
+			throw new Error('Unrecognized operation');
+	}
+	catch(err) {
+		pushError(inst, err);
+	}
+}
+
+function processTest(prefix, _) {
+	var context = new testerUtil.Context(db, prefix, processOperation, new DirectoryExtension());
+	try {
+		context.run(_);
+	}
+	catch(err) {
+		console.error('ERROR during operation \'' + context.ops[context.current].value.toString() + '\':');
+		console.error(err.stack);
+		process.exit(1);
+	}
+}
+
+processTest(startTestPrefix, _);

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -1,0 +1,754 @@
+#!/usr/bin/env node
+
+/*
+ * tester.js
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+//cmd line: node tester.js <test_prefix> <optional_cluster_file>
+var startTestPrefix = process.argv[2];
+if(process.argv.length === 5)
+	var clusterFile = process.argv[4];
+else
+	var clusterFile = '';
+
+var assert = require('assert');
+var fdb = require('../lib/fdb.js').apiVersion(parseInt(process.argv[3]));
+var fdbUtil = require('../lib/fdbUtil.js');
+var testerUtil = require('./util.js');
+var DirectoryExtension = require('./directory_extension.js');
+//fdb.options.setTraceEnable()
+
+var db = fdb.open(clusterFile);
+
+function pushError(inst, err) {
+	if(err) {
+		if(!err.code) {
+			console.error('ERROR during operation \'' + inst.op + '\':');
+			console.error(err.stack);
+			context.cb(err);
+		}
+
+		inst.push(fdb.tuple.pack([fdb.buffer('ERROR'), fdb.buffer(err.code.toString())]));
+	}
+
+	return err;
+}
+
+var rangeChoice = 0;
+function pushRange(itr, inst, prefixFilter, cb) {
+	return fdb.future.create(function(futureCb) {
+		var outArray = [];
+
+		function pushKV(kv) {
+			if(typeof prefixFilter === 'undefined' || prefixFilter === null ||  fdbUtil.buffersEqual(kv.key.slice(0, prefixFilter.length), prefixFilter)) {
+				outArray.push(kv.key);
+				outArray.push(kv.value);
+			}
+		}
+
+		function finish(err) {
+			if(!pushError(inst, err))
+				inst.push(fdb.tuple.pack(outArray));
+
+			futureCb();
+		}
+
+		//Test different methods for getting a range
+		if(inst.isDatabase) {
+			for(var i = 0; i < itr.length; ++i)
+				pushKV(itr[i]);
+
+			finish();
+		}
+		else if(rangeChoice % 4 === 0) {
+			itr.forEachBatch(function(res, itrCb) {
+				for(var i = 0 ; i < res.length; ++i)
+					pushKV(res[i]);
+
+				if(rangeChoice % 8 === 0)
+					setTimeout(itrCb, 0);
+				else
+					itrCb();
+			}, function(err, res) {
+				finish(err);
+			});
+		}
+		else if(rangeChoice % 4 === 1) {
+			itr.forEach(function(res, itrCb) {
+				pushKV(res);
+
+				if(rangeChoice % 8 === 1)
+					setTimeout(itrCb, 0);
+				else
+					itrCb();
+			}, function(err, res) {
+				finish(err);
+			});
+		}
+		else if(rangeChoice % 4 === 2) {
+			itr.toArray(function(err, arr) {
+				if(!err) {
+					for(var i = 0; i < arr.length; ++i)
+						pushKV(arr[i]);
+				}
+
+				finish(err);
+			});
+		}
+		else {
+			fdbUtil.whileLoop(function(loopCb) {
+				itr.next(function(err, res) {
+					if(err)
+						loopCb(err);
+					else if(!res)
+						loopCb(undefined, null);
+					else {
+						pushKV(res);
+						loopCb();
+					}
+				});
+			}, finish);
+		}
+
+		rangeChoice++;
+	})(cb);
+}
+
+var waitEmpty = fdb.transactional(function(tr, prefix, cb) {
+	var itr = tr.getRangeStartsWith(prefix, { limit: 1 });
+	itr.toArray(function(err, res) {
+		if(err)
+			cb(err, null);
+		else if(res.length > 0)
+			cb(new fdb.FDBError('', 1020), null);
+		else
+			cb(null, null);
+	});
+});
+
+var timeoutFuture = function(time) {
+	return fdb.future.create(function(futureCb) {
+		setTimeout(futureCb, time);
+	});
+};
+
+var checkWatches = function(db, watches, ready, error, expected, cb) {
+	var i = 0;
+	return fdbUtil.whileLoop(function(loopCb) {
+		if(i == watches.length) return loopCb(undefined, true); // terminate loop
+		if(!ready[i] && expected) {
+			return watches[i]
+			.then(function() {
+				loopCb(); // Recheck this watch when it finishes
+			})
+			.catch(function() {
+				loopCb(); // Check the error
+			});
+		}
+		assert.strictEqual(!ready[i] || expected, true, 'watch shouldnt be ready: ' + i);
+		if(typeof error[i] !== 'undefined') {
+			var tr = db.createTransaction();
+			return tr.onError(error[i])
+			.then(function() {
+				return false;
+			})(loopCb);
+		}
+
+		i++;
+		loopCb();
+	})(cb);
+}
+
+var testWatches = function(db, cb) {
+	return fdbUtil.whileLoop(function(loopCb) {
+		var ready = [ false, false, false, false ];
+		var error = [ undefined, undefined, undefined, undefined ];
+		var watches = [];
+
+		db.doTransaction(function(tr, innerCb) {
+			tr.set('w0', '0')
+			tr.set('w3', '3');
+			innerCb();
+		})
+		.then(function() {
+			return db.doTransaction(function(tr, innerCb) {
+				watches[0] = tr.watch('w0');
+				innerCb();
+			});
+		})
+		.then(function() {
+			return db.clearAndWatch('w1');
+		})
+		.then(function(w) {
+			watches[1] = w.watch;
+			return db.setAndWatch('w2', '2');
+		})
+		.then(function(w) {
+			watches[2] = w.watch;
+			return db.getAndWatch('w3');
+		})
+		.then(function(w) {
+			assert.strictEqual(w.value.toString(), '3', 'get and watch');
+			watches[3] = w.watch;
+
+			for(var i = 0; i < watches.length; ++i) {
+				(function(i) {
+					watches[i](function(err) {
+						if(!err) ready[i] = true;
+						else error[i] = err;
+					});
+				})(i);
+			}
+
+			return timeoutFuture(1000);
+		})
+		.then(function() {
+			return checkWatches(db, watches, ready, error, false);
+		})
+		.then(function(result) {
+			if(!result) return; // go around the loop again
+			return db.doTransaction(function(tr, innerCb) {
+				tr.set('w0', '0');
+				innerCb();
+			})
+			.then(function() {
+				return db.clear('w1');
+			})
+			.then(function() {
+				return timeoutFuture(5000);
+			})
+			.then(function() {
+				return checkWatches(db, watches, ready, error, false);
+			})
+			.then(function(result) {
+				if(!result) return; // go around the loop again
+				return db.set('w0', 'a')
+				.then(function() {
+					return db.set('w1', 'b');
+				})
+				.then(function() {
+					return db.clear('w2');
+				})
+				.then(function() {
+					return db.xor('w3', fdb.buffer.fromByteLiteral('\xff\xff'));
+				})
+				.then(function() {
+					return timeoutFuture(2000);
+				})
+				.then(function() {
+					return checkWatches(db, watches, ready, error, true);
+				})
+				.then(function(result) {
+					if(result) return null; //terminate loop
+					return;
+				});
+			});
+		})(loopCb);
+	})(cb);
+};
+
+var testLocality = function(db, cb) {
+	return db.doTransaction(function(tr, innerCb) {
+		tr.options.setTimeout(60*1000);
+		tr.options.setReadSystemKeys();
+
+		fdb.locality.getBoundaryKeys(tr, '', fdb.buffer.fromByteLiteral('\xff\xff'), function(err, itr) {
+			if(err) return innerCb(err);
+
+			var index = 0;
+			var start;
+			var end;
+			itr.forEach(function(boundaryKey, loopCb) {
+				if(err) return loopCb(err);
+
+				start = end;
+				end = boundaryKey;
+				if(index++ == 0)
+					return loopCb();
+
+				tr.getKey(fdb.KeySelector.lastLessThan(end), function(err, end) {
+					if(err) return loopCb(err);
+
+					fdb.locality.getAddressesForKey(tr, start, function(err, startAddresses) {
+						if(err) return loopCb(err);
+
+						fdb.locality.getAddressesForKey(tr, end, function(err, endAddresses) {
+							if(err) return loopCb(err);
+
+							for(var j = 0; j < startAddresses.length; ++j) {
+								var found = false;
+								for(var k = 0; k < endAddresses.length; ++k) {
+									if(startAddresses[j].toString() === endAddresses[k].toString()) {
+										found = true;
+										break;
+									}
+								}
+
+								if(!found) {
+									return loopCb(new Error('Locality not internally consistent'));
+								}
+							}
+
+							loopCb();
+						});
+					});
+				});
+			}, innerCb);
+		});
+	}, cb);
+};
+
+var numOperations = 0;
+function processOperation(context, inst, cb) {
+	//if(inst.op !== 'SWAP' && inst.op !== 'PUSH')
+		//console.log(context.prefix + ':', context.instructionIndex + '.', inst.op);
+
+	var promiseCb = function(err) {
+		pushError(inst, err);
+		cb();
+	};
+
+	if(inst.op === 'PUSH') {
+		inst.push(inst.tokens[1]);
+		cb();
+	}
+	else if(inst.op === 'POP') {
+		inst.pop()(promiseCb);
+	}
+	else if(inst.op === 'DUP') {
+		context.stack.pushEntry(context.stack.get(context.stack.length()-1));
+		cb();
+	}
+	else if(inst.op === 'EMPTY_STACK') {
+		context.stack = new testerUtil.Stack();
+		cb();
+	}
+	else if(inst.op === 'SWAP') {
+		inst.pop()
+		.then(function(index) {
+			assert.strictEqual(context.stack.length() > index, true, 'Cannot swap; stack too small');
+			index = context.stack.length() - index - 1;
+			if(context.stack.length() > index + 1) {
+				var tmp = context.stack.get(index);
+				context.stack.set(index, context.stack.popEntry());
+				context.stack.pushEntry(tmp);
+			}
+		})(promiseCb);
+	}
+	else if(inst.op === 'WAIT_FUTURE') {
+		inst.pop({withMetadata: true})
+		.then(function(stackEntry) {
+			context.stack.pushEntry(stackEntry);
+		})(promiseCb);
+	}
+	else if(inst.op === 'WAIT_EMPTY') {
+		inst.pop()
+		.then(function(waitKey) {
+			return waitEmpty(db, waitKey)
+			.then(function() {
+				inst.push('WAITED_FOR_EMPTY');
+			});
+		})(promiseCb);
+	}
+	else if(inst.op === 'START_THREAD') {
+		inst.pop()
+		.then(function(prefix) {
+			processTest(prefix, function(err, res) {
+				if(err) {
+					console.error('ERROR in Thread', prefix + ':');
+					console.error(err.stack);
+					process.exit(1);
+				}
+			});
+		})(promiseCb);
+	}
+	else if(inst.op === 'NEW_TRANSACTION') {
+		context.newTransaction();
+		cb();
+	}
+	else if(inst.op === 'USE_TRANSACTION') {
+		inst.pop()
+		.then(function(name) {
+			context.switchTransaction(name);
+		})(promiseCb);
+	}
+	else if(inst.op === 'SET') {
+		inst.pop({count: 2})
+		.then(function(params) {
+			var res = inst.tr.set(params[0], params[1]);
+
+			if(inst.isDatabase)
+				inst.push(res, true);
+		})(promiseCb);
+	}
+	else if(inst.op === 'CLEAR') {
+		inst.pop()
+		.then(function(key) {
+			var res = inst.tr.clear(key);
+
+			if(inst.isDatabase)
+				inst.push(res, true);
+		})(promiseCb);
+	}
+	else if(inst.op === 'CLEAR_RANGE') {
+		inst.pop({count: 2})
+		.then(function(params) {
+			var res = inst.tr.clearRange(params[0], params[1]);
+
+			if(inst.isDatabase)
+				inst.push(res, true);
+		})(promiseCb);
+	}
+	else if(inst.op === 'CLEAR_RANGE_STARTS_WITH') {
+		inst.pop()
+		.then(function(prefix) {
+			var res = inst.tr.clearRangeStartsWith(prefix);
+
+			if(inst.isDatabase)
+				inst.push(res, true);
+		})(promiseCb);
+	}
+	else if(inst.op === 'ATOMIC_OP') {
+		inst.pop({count: 3})
+		.then(function(params) {
+			var res = inst.tr[testerUtil.toJavaScriptName(params[0])](params[1], params[2]);
+
+			if(inst.isDatabase)
+				inst.push(res, true);
+		})(promiseCb);
+	}
+	else if(inst.op === 'COMMIT') {
+		inst.push(inst.tr.commit(), true);
+		cb();
+	}
+	else if(inst.op === 'RESET') {
+		inst.tr.reset();
+		cb();
+	}
+	else if(inst.op === 'CANCEL') {
+		inst.tr.cancel();
+		cb();
+	}
+	else if(inst.op === 'GET') {
+		inst.pop()
+		.then(function(key) {
+			inst.push(inst.tr.get(key), true);
+		})(promiseCb);
+	}
+	else if(inst.op === 'GET_RANGE') {
+		inst.pop({count: 5})
+		.then(function(params) {
+			var itr = inst.tr.getRange(params[0], params[1], { limit: params[2], reverse: params[3], streamingMode: params[4] });
+			if(inst.isDatabase) {
+				return itr.then(function(arr) {
+					return pushRange(arr, inst);
+				});
+			}
+			else {
+				return pushRange(itr, inst);
+			}
+		})(promiseCb);
+	}
+	else if(inst.op === 'GET_RANGE_SELECTOR') {
+		inst.pop({count: 10})
+		.then(function(params) {
+			var start = new fdb.KeySelector(params[0], params[1], params[2]);
+			var end = new fdb.KeySelector(params[3], params[4], params[5]);
+			var itr = inst.tr.getRange(start, end, { limit: params[6], reverse: params[7], streamingMode: params[8] });
+			if(inst.isDatabase) {
+				return itr.then(function(arr) {
+					return pushRange(arr, inst, params[9]);
+				});
+			}
+			else {
+				return pushRange(itr, inst, params[9]);
+			}
+		})(promiseCb);
+	}
+	else if(inst.op === 'GET_RANGE_STARTS_WITH') {
+		inst.pop({count: 4})
+		.then(function(params) {
+			var itr = inst.tr.getRangeStartsWith(params[0], { limit: params[1], reverse: params[2], streamingMode: params[3] });
+			if(inst.isDatabase) {
+				return itr.then(function(arr) {
+					return pushRange(arr, inst);
+				});
+			}
+			else {
+				return pushRange(itr, inst);
+			}
+		})(promiseCb);
+	}
+	else if(inst.op === 'GET_KEY') {
+		inst.pop({count: 4})
+		.then(function(params) {
+			var result = inst.tr.getKey(new fdb.KeySelector(params[0], params[1], params[2]))
+			.then(function(key) {
+				if(fdbUtil.buffersEqual(key.slice(0, params[3].length), params[3])) {
+					return key;
+				}
+				else if(fdb.buffer.toByteLiteral(key) < fdb.buffer.toByteLiteral(params[3])) {
+					return params[3];
+				}
+				else {
+					return fdbUtil.strinc(params[3]);
+				}
+			});
+
+			inst.push(result, true);
+		})(promiseCb);
+	}
+	else if(inst.op === 'READ_CONFLICT_RANGE') {
+		inst.pop({count: 2})
+		.then(function(params) {
+			inst.tr.addReadConflictRange(params[0], params[1]);
+			inst.push(fdb.buffer('SET_CONFLICT_RANGE'));
+		})(promiseCb);
+	}
+	else if(inst.op === 'WRITE_CONFLICT_RANGE') {
+		inst.pop({count: 2})
+		.then(function(params) {
+			inst.tr.addWriteConflictRange(params[0], params[1]);
+			inst.push(fdb.buffer('SET_CONFLICT_RANGE'));
+		})(promiseCb);
+	}
+	else if(inst.op === 'READ_CONFLICT_KEY') {
+		inst.pop()
+		.then(function(key) {
+			inst.tr.addReadConflictKey(key);
+			inst.push(fdb.buffer('SET_CONFLICT_KEY'));
+		})(promiseCb);
+	}
+	else if(inst.op === 'WRITE_CONFLICT_KEY') {
+		inst.pop()
+		.then(function(key) {
+			inst.tr.addWriteConflictKey(key);
+			inst.push(fdb.buffer('SET_CONFLICT_KEY'));
+		})(promiseCb);
+	}
+	else if(inst.op === 'DISABLE_WRITE_CONFLICT') {
+		inst.tr.options.setNextWriteNoWriteConflictRange();
+		cb();
+	}
+	else if(inst.op === 'GET_READ_VERSION') {
+		inst.tr.getReadVersion(function(err, res) {
+			if(!pushError(inst, err)) {
+				context.lastVersion = res;
+				inst.push(fdb.buffer('GOT_READ_VERSION'));
+			}
+			cb();
+		});
+	}
+	else if(inst.op === 'GET_COMMITTED_VERSION') {
+		try {
+			context.lastVersion = inst.tr.getCommittedVersion();
+
+			inst.push(fdb.buffer('GOT_COMMITTED_VERSION'));
+			cb();
+		}
+		catch(err) {
+			pushError(inst, err);
+			cb();
+		}
+	}
+	else if(inst.op === 'GET_VERSIONSTAMP') {
+		try {
+			inst.push(inst.tr.getVersionstamp(), true)
+			cb();
+		}
+		catch(err) {
+			pushError(inst, err);
+			cb();
+		}
+	}
+	else if(inst.op === 'SET_READ_VERSION') {
+		assert.notStrictEqual(typeof context.lastVersion, 'undefined', 'Cannot set read version; version has never been read');
+		inst.tr.setReadVersion(context.lastVersion);
+		cb();
+	}
+	else if(inst.op === 'ON_ERROR') {
+		inst.pop()
+		.then(function(errorCode) {
+			var testErr = new fdb.FDBError('', errorCode);
+
+			inst.push(inst.tr.onError(testErr), true);
+		})(promiseCb);
+	}
+	else if(inst.op === 'TUPLE_PACK') {
+		inst.pop()
+		.then(function(numParams) {
+			return inst.pop({count: numParams})
+			.then(function(params) {
+				inst.push(fdb.tuple.pack(params));
+			});
+		})(promiseCb);
+	}
+	else if(inst.op === 'TUPLE_UNPACK') {
+		inst.pop()
+		.then(function(packedTuple) {
+			var arr = fdb.tuple.unpack(packedTuple);
+			for(var i = 0; i < arr.length; ++i)
+				inst.push(fdb.tuple.pack([arr[i]]));
+		})(promiseCb);
+	}
+	else if(inst.op === 'TUPLE_RANGE') {
+		inst.pop()
+		.then(function(numParams) {
+			return inst.pop({count: numParams})
+			.then(function(params) {
+				var range = fdb.tuple.range(params);
+				inst.push(range.begin);
+				inst.push(range.end);
+			});
+		})(promiseCb);
+	}
+	else if(inst.op === 'TUPLE_SORT') {
+		inst.pop()
+		.then(function(numParams) {
+			return inst.pop({count: numParams})
+			.then(function(params) {
+				var tuples = [];
+				for(var i = 0; i < params.length; ++i)
+					tuples.push(fdb.tuple.unpack(params[i]));
+				tuples.sort(fdb.tuple.compare);
+				for(var i = 0; i < tuples.length; ++i)
+					inst.push(fdb.tuple.pack(tuples[i]));
+			});
+		})(promiseCb);
+	}
+	else if(inst.op === 'SUB') {
+		inst.pop({count: 2})
+		.then(function(params) {
+			inst.push(params[0] - params[1]);
+		})(promiseCb);
+	}
+	else if(inst.op === 'ENCODE_FLOAT') {
+		inst.pop()
+		.then(function(fBytes) {
+			inst.push(fdb.tuple.Float.fromBytes(fBytes));
+		})(promiseCb);
+	}
+	else if(inst.op === 'ENCODE_DOUBLE') {
+		inst.pop()
+		.then(function(dBytes) {
+			inst.push(fdb.tuple.Double.fromBytes(dBytes));
+		})(promiseCb);
+	}
+	else if(inst.op === 'DECODE_FLOAT') {
+		inst.pop()
+		.then(function(fVal) {
+			inst.push(fVal.toBytes());
+		})(promiseCb);
+	}
+	else if(inst.op === 'DECODE_DOUBLE') {
+		inst.pop()
+		.then(function(dVal) {
+			inst.push(dVal.toBytes());
+		})(promiseCb);
+	}
+	else if(inst.op === 'CONCAT') {
+		inst.pop({count: 2})
+		.then(function(params) {
+			if(Buffer.isBuffer(params[0])) {
+				inst.push(Buffer.concat([params[0], params[1]]))
+			}
+			else {
+				inst.push(params[0] + params[1]);
+			}
+		})(promiseCb);
+	}
+	else if(inst.op === 'LOG_STACK') {
+		inst.pop()
+		.then(function(prefix) {
+			return fdbUtil.whileLoop(function(loopCb) {
+				inst.pop({count: 100, withMetadata: true})
+				.then(function(items) {
+					if(items.length == 0) {
+						return null
+					}
+					return db.doTransaction(function(tr, innerCb) {
+						for(var index = 0; index < items.length; ++index) {
+							var entry = items[items.length - index - 1];
+							var packedSubKey = fdb.tuple.pack([context.stack.length() + index, entry.instructionIndex]);
+
+							var packedValue = fdb.tuple.pack([entry.item]);
+							if(packedValue.length > 40000)
+								packedValue = packedValue.slice(0, 40000);
+
+							tr.set(Buffer.concat([prefix, packedSubKey], prefix.length + packedSubKey.length), packedValue);
+						}
+
+						innerCb();
+					});
+				})(loopCb);
+			});
+		})(promiseCb);
+	}
+	else if(inst.op === 'UNIT_TESTS') {
+		db.options.setLocationCacheSize(100001);
+		db.doTransaction(function(tr, innerCb) {
+			tr.options.setPrioritySystemImmediate();
+			tr.options.setPriorityBatch();
+			tr.options.setCausalReadRisky();
+			tr.options.setCausalWriteRisky();
+			tr.options.setReadYourWritesDisable();
+			tr.options.setReadAheadDisable();
+			tr.options.setReadSystemKeys();
+			tr.options.setAccessSystemKeys();
+			tr.options.setDurabilityDevNullIsWebScale();
+			tr.options.setTimeout(60*1000);
+			tr.options.setRetryLimit(50);
+			tr.options.setMaxRetryDelay(100);
+			tr.options.setUsedDuringCommitProtectionDisable();
+			tr.options.setTransactionLoggingEnable('my_transaction');
+			tr.options.setReadLockAware()
+			tr.options.setLockAware()
+
+			tr.get(fdb.buffer.fromByteLiteral('\xff'), innerCb);
+		})
+		.then(function() {
+			return testWatches(db);
+		})
+		.then(function() {
+			return testLocality(db);
+		})
+		.then(cb)
+		.catch(function(err) {
+			cb('Unit tests failed: ' + err + "\n" + err.stack);
+		});
+	}
+	else if(testerUtil.startsWith(inst.op, 'DIRECTORY_')) {
+		context.directoryExtension.processInstruction(inst, cb);
+	}
+	else {
+		cb('Unrecognized operation');
+	}
+}
+
+function processTest(prefix, cb) {
+	var context = new testerUtil.Context(db, prefix, processOperation, new DirectoryExtension());
+	context.run(cb);
+}
+
+processTest(startTestPrefix, function(err, res) {
+	if(err)
+		process.exit(1);
+});

--- a/tests/tuple_test.js
+++ b/tests/tuple_test.js
@@ -1,0 +1,101 @@
+/*
+ * tuple_test.js
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var fdb = require('../lib/fdb.js').apiVersion(510);
+var fdbModule = require('../lib/fdbModule.js');
+
+console.log(fdb.tuple.pack([-Math.pow(2,53)]));
+console.log(fdb.tuple.pack([-Math.pow(2,53)+1]));
+
+console.log(fdb.tuple.unpack(fdb.tuple.pack([-Math.pow(2,53)])));
+console.log(fdb.tuple.unpack(fdb.tuple.pack([-Math.pow(2,53)+1])));
+
+try {
+	console.log(fdb.tuple.unpack(fdb.buffer.fromByteLiteral('\x0d\xdf\xff\xff\xff\xff\xff\xfe')));
+}
+catch(err) {
+	console.log(err);
+}
+
+console.log(fdb.tuple.pack([0xff * 0xff]));
+console.log(fdb.tuple.pack([0xffffffff + 100 ]));
+console.log(fdb.buffer.printable(fdb.tuple.pack(['begin', [true, null, false], 'end'])))
+console.log(fdb.tuple.unpack(fdb.buffer.fromByteLiteral('\x1a\xff\xff\xff\xff\xff\xff')));
+console.log(fdb.tuple.unpack(fdb.tuple.pack(['TEST', 'herp', 1, -10, 393493, '\u0000abc', 0xffffffff + 100, true, false, [new Boolean(true), null, new Boolean(false), 0, 'asdf'], null])));
+console.log(fdb.buffer.printable(fdb.tuple.pack([[[[['three']]], 'two'], 'one'])))
+console.log(fdb.tuple.range(['TEST', 1]));
+console.log(fdb.buffer.printable(fdb.tuple.pack([fdb.tuple.Float.fromBytes(new Buffer('402df854', 'hex')), fdb.tuple.Double.fromBytes(new Buffer('4005BF0A8B145769', 'hex')), new fdb.tuple.UUID(new Buffer('deadc0deba5eba115ca1ab1edeadc0de', 'hex'))])))
+console.log(fdb.tuple.unpack(fdb.tuple.pack([fdb.tuple.Float.fromBytes(new Buffer('2734236f', 'hex'))])))
+
+tuples = [
+    [1,2],
+    [1],
+    [2],
+    [true],
+    [false],
+    [1,true],
+    [1,false],
+    [1, []],
+    [1, [null]],
+    [1, [0]],
+    [1, [1]],
+    [1, [0,1,2]],
+    [null],
+    []
+];
+tuples.sort(fdb.tuple.compare);
+console.log(tuples);
+
+tuples = [
+    [fdb.tuple.Float.fromBytes(new Buffer('2734236f', 'hex'))], // A really small value.
+    [fdb.tuple.Float.fromBytes(new Buffer('80000000', 'hex'))], // -0.0
+    [new fdb.tuple.Float(0.0)],
+    [new fdb.tuple.Float(3.14)],
+    [new fdb.tuple.Float(-3.14)],
+    [new fdb.tuple.Float(2.7182818)],
+    [new fdb.tuple.Float(-2.7182818)],
+    [fdb.tuple.Float.fromBytes(new Buffer('7f800000', 'hex'))], // Infinity
+    [fdb.tuple.Float.fromBytes(new Buffer('7fffffff', 'hex'))], // NaN
+    [fdb.tuple.Float.fromBytes(new Buffer('ffffffff', 'hex'))], // -NaN
+];
+tuples.sort(fdb.tuple.compare);
+console.log(tuples);
+
+// Float overruns.
+const floats = [ 2.037036e90, -2.037036e90, 4.9090935e-91, -4.9090935e-91, 2.345624805922133125e14, -2.345624805922133125e14 ];
+for (var i = 0; i < floats.length; i++) {
+    var f = floats[i];
+    console.log(f + " -> " + fdb.tuple.Float.fromBytes((new fdb.tuple.Float(f)).toBytes()).value);
+}
+
+// Float type errors.
+try {
+    console.log((new fdb.tuple.Float("asdf")).toBytes());
+} catch (e) {
+    console.log("Caught!");
+    console.log(e);
+}
+
+try {
+    console.log(fdbModule.toFloat(3.14, 2.718));
+} catch (e) {
+    console.log("Caught!");
+    console.log(e);
+}

--- a/tests/util.js
+++ b/tests/util.js
@@ -1,0 +1,276 @@
+/*
+ * util.js
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+var fdb = require('../lib/fdb.js').apiVersion(parseInt(process.argv[3]));
+var util = require('../lib/fdbUtil.js');
+
+function Stack() {
+	this.stack = [];
+}
+
+Stack.prototype.length = function() {
+	return this.stack.length;
+};
+
+Stack.prototype.get = function(index) {
+	return this.stack[index];
+};
+
+Stack.prototype.set = function(index, val) {
+	this.stack[index] = val;
+};
+
+Stack.prototype.push = function(instructionIndex, item, isFuture) {
+	if(typeof isFuture === 'undefined')
+			isFuture = false;
+	
+	this.pushEntry({ instructionIndex: instructionIndex, item: item, isFuture: isFuture });
+};
+
+Stack.prototype.pushEntry = function(entry) {
+	this.stack.push(entry);
+};
+
+Stack.prototype.pop = function(options, callback) {
+	var self = this;
+	return fdb.future.create(function(futureCb) {
+		if(typeof options === 'undefined')
+			options = {};
+
+		var count = options.count;
+		if(typeof count === 'undefined')
+			count = 1;
+
+		var params = self.stack.slice(self.stack.length-count).reverse();
+		self.stack = self.stack.slice(0, self.stack.length-count);
+
+		var index = 0;
+
+		var itemCallback = function(err, val) {
+			if(err) {
+				//console.log(err);
+				params[index].item = fdb.tuple.pack([fdb.buffer('ERROR'), fdb.buffer(err.code.toString())]);
+			}
+			else if(val)
+				params[index].item = val;
+			else
+				params[index].item = fdb.buffer('RESULT_NOT_PRESENT');
+
+			params[index].isFuture = false;
+
+			if(!options.withMetadata)
+				params[index] = params[index].item;
+
+			index++;
+			processNext();
+		};
+
+		var processNext = function() {
+			while(true) {
+				if(index >= params.length) {
+					if(typeof options.count === 'undefined')
+						futureCb(undefined, params[0]);
+					else
+						futureCb(undefined, params);
+
+					return;
+				}
+
+				if(params[index].isFuture) {
+					params[index].item(itemCallback);
+					return;
+				}
+
+				if(!options.withMetadata)
+					params[index] = params[index].item;
+
+				index++;
+			}
+		};
+
+		processNext();
+	})(callback);
+};
+
+Stack.prototype.popEntry = function() {
+	return this.stack.pop();
+};
+
+function Context(db, prefix, processInstruction, directoryExtension) {
+	var range = fdb.tuple.range([fdb.buffer(prefix)]);
+
+	this.prefix = prefix;
+	this.stack = new Stack();
+	this.db = db;
+	this.next = range.begin;
+	this.end = range.end;
+	this.processInstruction = processInstruction;
+	this.instructionIndex = -1;
+	this.directoryExtension = directoryExtension;
+	this.trName = prefix;
+}
+
+Context.trMap = {}
+
+Context.prototype.newTransaction = function() {
+	Context.trMap[this.trName] = this.db.createTransaction();
+};
+
+Context.prototype.switchTransaction = function(name) {
+	this.trName = name;
+	if(typeof Context.trMap[this.trName] === 'undefined') {
+		this.newTransaction();
+	}
+};
+
+Context.prototype.updateResults = function(results) {
+	this.ops = results;
+	this.current = 0;
+	this.next = fdb.KeySelector.firstGreaterThan(results[results.length-1].key);
+};
+
+var issueInstruction = function(context, cb) {
+	try {
+		var tokens = fdb.tuple.unpack(context.ops[context.current].value);
+		var op = tokens[0].toString();
+
+		var snapshotStr = '_SNAPSHOT';
+		var databaseStr = '_DATABASE';
+
+		var isSnapshot = endsWith(op, snapshotStr);
+		var isDatabase = endsWith(op, databaseStr);
+
+		var tr = Context.trMap[context.trName];
+		if(isSnapshot) {
+			op = op.substr(0, op.length - snapshotStr.length);
+			tr = tr.snapshot;
+		}
+		else if(isDatabase) {
+			op = op.substr(0, op.length - databaseStr.length);
+			tr = context.db;
+		}
+
+		var inst = new Instruction(context, tr, op, tokens, isDatabase, isSnapshot);
+		context.processInstruction(context, inst, cb);
+	}
+	catch(e) {
+		cb(e);
+	}
+};
+
+Context.prototype.run = function(cb) {
+	var self = this;
+
+	function getInstructions(instCb) {
+		self.db.doTransaction(function(tr, trCb) {
+			tr.getRange(self.next, self.end, { limit: 1000 } ).toArray(function(rangeErr, rangeRes) {
+				if(rangeErr) return trCb(rangeErr);
+
+				trCb(undefined, rangeRes);
+			});
+		}, function(err, rangeRes) {
+			if(err) return instCb(err);
+			if(rangeRes.length > 0)
+				self.updateResults(rangeRes);
+			instCb();
+		});
+	}
+
+	function readAndExecuteInstructions(loopCb) {
+		++self.instructionIndex;
+		if(!self.ops || ++self.current === self.ops.length) {
+			getInstructions(function(err) {
+				if(err) return loopCb(err);
+				if(self.current < self.ops.length)
+					issueInstruction(self, loopCb);
+				else
+					loopCb(undefined, null); // terminate the loop	
+			});
+		}
+		else
+			issueInstruction(self, loopCb);
+	}
+
+	util.whileLoop(readAndExecuteInstructions, function(err) {
+		if(err) {
+			if(self.ops && self.current < self.ops.length)
+				console.error('ERROR during operation \'' + self.ops[self.current].value.toString() + '\':');
+			else
+				console.error('ERROR getting operations:');
+
+			if(err.stack)
+				console.error(err.stack);
+			else
+				console.error(err);
+		}
+
+		cb(err);
+	});
+};
+
+function Instruction(context, tr, op, tokens, isDatabase, isSnapshot) {
+	this.context = context;
+	this.tr = tr;
+	this.op = op;
+	this.tokens = tokens;
+	this.isDatabase = isDatabase;
+	this.isSnapshot = isSnapshot;
+}
+
+Instruction.prototype.pop = function(options, callback) {
+	return this.context.stack.pop(options, callback);
+};
+
+Instruction.prototype.push = function(item, isFuture) {
+	this.context.stack.push(this.context.instructionIndex, item, isFuture);
+};
+
+function toJavaScriptName(name) {
+	name = name.toString().toLowerCase();
+	var start = 0;
+	while(start < name.length) {
+		start = name.indexOf('_', start);
+		if(start === -1)
+			break;
+
+		name = name.slice(0, start) + name[start+1].toUpperCase() + name.slice(start+2);
+	}
+
+	return name.replace(/_/g, '');
+}
+
+function startsWith(str, prefixStr) {
+	return str.length >= prefixStr.length && str.substr(0, prefixStr.length) === prefixStr;
+}
+
+function endsWith(str, endStr) {
+	return str.length >= endStr.length && str.substr(str.length - endStr.length) === endStr;
+}
+
+module.exports = { 
+	Stack: Stack, 
+	Context: Context, 
+	Instruction: Instruction, 
+	toJavaScriptName: toJavaScriptName,
+	startsWith: startsWith,
+	endsWith: endsWith
+};


### PR DESCRIPTION
I dug into the repo history and recovered the original tests for Node.js bindings. These were removed in this pull request: [apple/foundationdb#130 - Remove old Node.js bindings](apple/foundationdb#130)

Haven't run the tests since they all import from `../lib`. I thought these would be useful reference for preparing new tests.